### PR TITLE
LPSC2018 Abstract Stereo Configs and README Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ Scripts for processing CTX and HiRISE data are organized into their own subdirec
 4. asp_hirise_pc_align2dem.sh
 
 ## Referencing This Workflow ##
-Please cite the following LPSC abstract in any publications that make use of this work or derivatives thereof:
-Mayer, D.P. and Kite, E.S., "An Integrated Workflow for Producing Digital Terrain Models of Mars from CTX and HiRISE Stereo Data Using the NASA Ames Stereo Pipeline," (2016) LPSC XLVII, Abtr. #1241. <http://www.hou.usra.edu/meetings/lpsc2016/pdf/1241.pdf>
-E-poster: <http://www.lpi.usra.edu/meetings/lpsc2016/eposter/1241.pdf>
+Please cite one or both of the following LPSC abstracts in any publications that make use of this work or derivatives thereof:
+1. Mayer, D.P. and Kite, E.S., "An Integrated Workflow for Producing Digital Terrain Models of Mars from CTX and HiRISE Stereo Data Using the NASA Ames Stereo Pipeline," (2016) LPSC XLVII, Abstr. #1241. <https://www.hou.usra.edu/meetings/lpsc2016/pdf/1241.pdf>
+E-poster: <https://www.lpi.usra.edu/meetings/lpsc2016/eposter/1241.pdf>
+2. Mayer, D. P., "An Improved Workflow for Producing Digital Terrain Models of Mars from CTX Stereo Data Using the NASA Ames Stereo Pipeline," (2018) LPSC XLIX, Abstr. #1604. <https://www.hou.usra.edu/meetings/lpsc2018/pdf/1604.pdf>
+E-poster: <https://www.hou.usra.edu/meetings/lpsc2018/eposter/1604.pdf>
+
 
 The Ames Stereo Pipeline itself should be cited according to guidelines outlined in the official ASP documentation.

--- a/config/ctx_map_disp_filter_11_21_019.stereo
+++ b/config/ctx_map_disp_filter_11_21_019.stereo
@@ -1,0 +1,77 @@
+# -*- mode: sh -*-
+
+# Pre-Processing / stereo_pprc
+################################################################
+
+# Pre-alignment options
+#
+# Available choices are (however not all are supported by all sessions):
+#    NONE           (Recommended for anything map projected)
+#    EPIPOLAR       (Recommended for Pinhole Sessions)
+#    HOMOGRAPHY     (Recommended for ISIS wide-angle shots)
+#    AFFINEEPIPOLAR (Recommended for ISIS narrow-angle and DG sessions)
+alignment-method none
+
+# Intensity Normalization
+#force-use-entire-range       # Use entire input range
+
+# Select a preprocessing filter:
+#
+# 0 - None
+# 1 - Subtracted Mean
+# 2 - Laplacian of Gaussian (recommended)
+prefilter-mode 2
+
+# Kernel size (1-sigma) for pre-processing
+#
+# Recommend 1.4 px for Laplacian of Gaussian
+# Recommend 25 px for Subtracted Mean
+prefilter-kernel-width 1.5
+
+# Integer Correlation / stereo_corr
+################################################################
+
+# Select a cost function to use for initialization:
+#
+# 0 - absolute difference (fast)
+# 1 - squared difference  (faster .. but usually bad)
+# 2 - normalized cross correlation (recommended)
+cost-mode 2
+
+# Initialization step: correlation kernel size
+corr-kernel 25 25
+
+# Initializaion step: correlation window size
+# corr-search -80 -2 20 2
+
+# Subpixel Refinement / stereo_rfne
+################################################################
+
+# Subpixel step: subpixel modes
+#
+# 0 - disable subpixel correlation (fastest)
+# 1 - parabola fitting (draft mode - not as accurate)
+# 2 - affine adaptive window, bayes EM weighting (slower, but much more accurate)
+# 3 - affine window, (intermediate speed, results similar to bayes EM)
+subpixel-mode 2
+
+# Subpixel step: correlation kernel size
+subpixel-kernel 21 21
+
+# Post Filtering / stereo_fltr
+################################################################
+
+# Filter disparity map using median filter followed by adaptive texture filter
+rm-cleanup-passes 0
+median-filter-size 11
+texture-smooth-size 21
+texture-smooth-scale 0.19
+
+# Triangulation / stereo_tri
+################################################################
+
+# Size max of the universe in meters and altitude off the ground.
+# Setting both values to zero turns this post-processing step off.
+near-universe-radius 0.0
+far-universe-radius 0.0
+

--- a/config/ctx_map_disp_filter_17_25_025.stereo
+++ b/config/ctx_map_disp_filter_17_25_025.stereo
@@ -1,0 +1,77 @@
+# -*- mode: sh -*-
+
+# Pre-Processing / stereo_pprc
+################################################################
+
+# Pre-alignment options
+#
+# Available choices are (however not all are supported by all sessions):
+#    NONE           (Recommended for anything map projected)
+#    EPIPOLAR       (Recommended for Pinhole Sessions)
+#    HOMOGRAPHY     (Recommended for ISIS wide-angle shots)
+#    AFFINEEPIPOLAR (Recommended for ISIS narrow-angle and DG sessions)
+alignment-method none
+
+# Intensity Normalization
+#force-use-entire-range       # Use entire input range
+
+# Select a preprocessing filter:
+#
+# 0 - None
+# 1 - Subtracted Mean
+# 2 - Laplacian of Gaussian (recommended)
+prefilter-mode 2
+
+# Kernel size (1-sigma) for pre-processing
+#
+# Recommend 1.4 px for Laplacian of Gaussian
+# Recommend 25 px for Subtracted Mean
+prefilter-kernel-width 1.5
+
+# Integer Correlation / stereo_corr
+################################################################
+
+# Select a cost function to use for initialization:
+#
+# 0 - absolute difference (fast)
+# 1 - squared difference  (faster .. but usually bad)
+# 2 - normalized cross correlation (recommended)
+cost-mode 2
+
+# Initialization step: correlation kernel size
+corr-kernel 25 25
+
+# Initializaion step: correlation window size
+# corr-search -80 -2 20 2
+
+# Subpixel Refinement / stereo_rfne
+################################################################
+
+# Subpixel step: subpixel modes
+#
+# 0 - disable subpixel correlation (fastest)
+# 1 - parabola fitting (draft mode - not as accurate)
+# 2 - affine adaptive window, bayes EM weighting (slower, but much more accurate)
+# 3 - affine window, (intermediate speed, results similar to bayes EM)
+subpixel-mode 2
+
+# Subpixel step: correlation kernel size
+subpixel-kernel 21 21
+
+# Post Filtering / stereo_fltr
+################################################################
+
+# Filter disparity map using median filter followed by adaptive texture filter
+rm-cleanup-passes 0
+median-filter-size 17
+texture-smooth-size 25
+texture-smooth-scale 0.25
+
+# Triangulation / stereo_tri
+################################################################
+
+# Size max of the universe in meters and altitude off the ground.
+# Setting both values to zero turns this post-processing step off.
+near-universe-radius 0.0
+far-universe-radius 0.0
+

--- a/config/ctx_map_disp_filter_7_13_0.13.stereo
+++ b/config/ctx_map_disp_filter_7_13_0.13.stereo
@@ -1,0 +1,16 @@
+alignment-method none
+prefilter-mode 2
+prefilter-kernel-width 1.5
+cost-mode 2
+corr-kernel 25 25
+subpixel-mode 2
+subpixel-kernel 21 21
+
+rm-cleanup-passes 0
+median-filter-size 7
+texture-smooth-size 13
+texture-smooth-scale 0.13
+
+near-universe-radius 0.0
+far-universe-radius 0.0
+

--- a/config/ctx_nomap_sgm.stereo
+++ b/config/ctx_nomap_sgm.stereo
@@ -1,0 +1,18 @@
+# Use SGM
+stereo-algorithm 1
+
+# Assuming input is not map-projected, use affineepipolar alignment
+alignment-method affineepipolar
+
+corr-seed-mode 0
+corr-tile-size 1600
+
+sgm-collar-size 400
+
+cost-mode 4
+corr-kernel 7 7
+xcorr-threshold -1
+
+median-filter-size 5
+texture-smooth-size 15
+texture-smooth-scale 0.15


### PR DESCRIPTION
Added example CTX stereo configs that use disparity map smoothing, SGM. Updated README with LPSC2018 abstract and E-poster links.